### PR TITLE
feat: adds a smart fetch to the nonodo version and updates it

### DIFF
--- a/src/nonodo.js
+++ b/src/nonodo.js
@@ -17,7 +17,7 @@ import { SingleBar, Presets } from "cli-progress";
 import AdmZip from "adm-zip";
 
 const PACKAGE_NONODO_VERSION =
-  process.env.PACKAGE_NONODO_VERSION ?? "1.0.4";
+  process.env.PACKAGE_NONODO_VERSION ?? await getLatestNonodoRelease();
 const PACKAGE_NONODO_URL = new URL(
   process.env.PACKAGE_NONODO_URL ??
   `https://github.com/Calindra/nonodo/releases/download/v${PACKAGE_NONODO_VERSION}/`,
@@ -38,6 +38,23 @@ function getPlatform() {
   const plat = platform();
   if (plat === "win32") return "windows";
   else return plat;
+}
+
+async function getLatestNonodoRelease() {
+  try {
+    const response = await fetch('https://api.github.com/repos/Calindra/nonodo/releases');
+    const data = await response.json();
+    const latestRelease = data.find(release => release.prerelease);
+    if (latestRelease) {
+      const version = latestRelease.tag_name.match(/\d+\.\d+\.\d+/);
+      return version ? version[0] : '1.1.0'; // Fallback to default version if no version match is found
+    } else {
+      return '1.1.0'; // Fallback to default version if no pre-release found
+    }
+  } catch (error) {
+    console.error('Error fetching the latest release:', error);
+    return '1.1.0'; // Fallback to default version if there's an error
+  }
 }
 
 function getArch() {


### PR DESCRIPTION
# Brief

Adds a smart fetch to the nonodo version and updates it. This will help to keep the project updated to the newest releases of nonodo.

## Activity

- Adds function to fetch newest releases
- Uses the pre-release tag to check the newest nonodo version instead of hardcoded

## Evidences

![image](https://github.com/gbarros/noextra/assets/4421825/caea20a2-1ff7-4a02-852b-4fef8fc61cb1)
